### PR TITLE
Fix search and checkout loading guards

### DIFF
--- a/template/js/checkout.js
+++ b/template/js/checkout.js
@@ -1,34 +1,62 @@
 import '#template/js/checkout'
 import './custom-js/checkout'
 import ecomCart from '@ecomplus/shopping-cart'
+
 var lessUnit = document.getElementById('lessUnit')
 var firstphrase = document.getElementById('lessSome')
 var lastphrase = document.getElementById('noMore')
+var containerCalc = document.getElementById('containerCalc')
+var lastUnitsBar = document.getElementById('lastUnitsBar')
+var percentBarEl = document.getElementById('percentBar')
 var lessQuantity = window.giftWarning || 250
-lessUnit.innerHTML = window.ecomUtils.formatMoney(lessQuantity, 'BRL', 'pt_br')
+
+function formatMoney (value) {
+  return window.ecomUtils && window.ecomUtils.formatMoney
+    ? window.ecomUtils.formatMoney(value, 'BRL', 'pt_br')
+    : 'R$ ' + Number(value || 0).toFixed(2).replace('.', ',')
+}
+
+function setDisplay (el, display) {
+  if (el) {
+    el.style.display = display
+  }
+}
+
+function updateProgress (value) {
+  if (lastUnitsBar) {
+    lastUnitsBar.style.width = value
+  }
+  if (percentBarEl) {
+    percentBarEl.innerHTML = value
+  }
+}
+
+if (lessUnit) {
+  lessUnit.innerHTML = formatMoney(lessQuantity)
+}
+
 ecomCart.on('change', ({ data }) => {
   var cartCalc = document.querySelectorAll('#cart')
-  if (cartCalc.length) {
-    document.getElementById('containerCalc').style.display = 'block'
-    var checkoutButton = document.querySelector('.cart__btn-checkout')
+  if (containerCalc && cartCalc.length) {
+    containerCalc.style.display = 'block'
     var percentBar
     var countQuantity = data.subtotal
     var evalQuantity = lessQuantity - countQuantity
     if (evalQuantity > 0) {
-      lessUnit.innerHTML = window.ecomUtils.formatMoney(evalQuantity, 'BRL', 'pt_br')
+      if (lessUnit) {
+        lessUnit.innerHTML = formatMoney(evalQuantity)
+      }
       percentBar = Math.round(countQuantity / lessQuantity * 100) + '%'
-      document.getElementById('lastUnitsBar').style.width = percentBar
-      document.getElementById('percentBar').innerHTML = percentBar
-      firstphrase.style.display = 'block'
-      lastphrase.style.display = 'none'
+      updateProgress(percentBar)
+      setDisplay(firstphrase, 'block')
+      setDisplay(lastphrase, 'none')
     } else {
       percentBar = '100%'
-      firstphrase.style.display = 'none'
-      lastphrase.style.display = 'block'
-      document.getElementById('lastUnitsBar').style.width = percentBar
-      document.getElementById('percentBar').innerHTML = percentBar
+      setDisplay(firstphrase, 'none')
+      setDisplay(lastphrase, 'block')
+      updateProgress(percentBar)
     }
-  } else {
-    document.getElementById('containerCalc').style.display = 'none'
+  } else if (containerCalc) {
+    containerCalc.style.display = 'none'
   }
 })

--- a/template/js/custom-js/js/ProductCard.js
+++ b/template/js/custom-js/js/ProductCard.js
@@ -181,15 +181,15 @@ export default {
         this.isFavorite = toggleFavorite(this.body._id, this.ecomPassport)
       }
     },
-    qtd (el,quantity) { 
-      const { body } = this     
-      let me = $("[product_quantity='"+ el +"']");
-      let atual = parseInt(me.closest('label').find('input').val());
-      atual = atual + parseInt(quantity);
-
-      if(atual < 1){atual = 1}
-      me.closest('label').find('input').val(atual);
-    
+    qtd (el, quantity) {
+      const input = document.querySelector(`[product_quantity="${el}"]`)
+      if (!input) {
+        return
+      }
+      const currentValue = parseInt(input.value, 10) || 1
+      const nextValue = Math.max(1, currentValue + (parseInt(quantity, 10) || 0))
+      input.value = nextValue
+      input.dispatchEvent(new Event('change', { bubbles: true }))
     },
 
     getListContext (element) {
@@ -297,9 +297,9 @@ export default {
                   })
               }
             }
-            const { quantity, price } = data
-            //ecomCart.addProduct({ ...product, quantity : parseInt($("[product_quantity='"+ product._id +"']")), price })
-            ecomCart.addProduct({ ...product }, '', parseInt(document.querySelector("[product_quantity='"+ product._id +"']").value))
+            const quantityInput = document.querySelector(`[product_quantity="${product._id}"]`)
+            const quantity = quantityInput ? parseInt(quantityInput.value, 10) : 1
+            ecomCart.addProduct({ ...product }, '', quantity || 1)
           })
           .catch(err => {
             console.error(err)


### PR DESCRIPTION
## O que muda

- Protege o JS customizado do checkout contra elementos ainda ausentes no DOM (#lessUnit, #containerCalc, barra de progresso).
- Protege os controles de quantidade dos cards de produto para nao quebrar busca/listagens quando o input ainda nao existe.

## Validacao

- Build parcial local passou: npm run build -- --prerender=index,app/index,search,404,blog,admin/index --prerender-limit=0.
- O aviso do GitHub Actions anexado e de deprecacao futura de actions em Node 20; o run mais recente de deploy esta verde e isso nao e a causa direta do bug de runtime.